### PR TITLE
Add a ssh_command_generator config for displaying when generated ssh command fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,10 @@ The following options are also available:
   Default: false
 * impact - analyze local changes to determine which hosts/roles to test.
   Default: false
-* ssh_cmd_template - A variable to supply a custom ssh command generator which
-  will be invoked by TT to generate a vanilla command. This can be expressed in a template
-  format, with the arguments supplied using `ssh_gen_args`
+* ssh_cmd_gen_template - A variable to supply a custom ssh command
+  generator which will be invoked by TT to generate a vanilla command.
+  This can be expressed in a template format, with the arguments
+  supplied using `ssh_cmd_gen_args`
   Default: nil
 
 ## Plugin

--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ The following options are also available:
   Default: false
 * impact - analyze local changes to determine which hosts/roles to test.
   Default: false
+* ssh_cmd_template - A variable to supply a custom ssh command generator which
+  will be invoked by TT to generate a vanilla command. This can be expressed in a template
+  format, with the arguments supplied using `ssh_gen_args`
+  Default: nil
 
 ## Plugin
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ Custom output of calculated impact, useful if defining either of the other
 impact hooks. Must return a truthy value to prevent the default output from
 printing.
 
+* self.post_error(dryrun, exception, mode, hostname)
+
+A hook which will be called just before taste-tester throws an exception/exits.
+Passes down the `exception` object and the `mode` taste-tester was invoked with
+for further analysis and doing any additional logging, output, or cleanup.
+
 ## Plugin example
 
 This is an example `/etc/taste-tester-plugin.rb` to add a user-defined string

--- a/README.md
+++ b/README.md
@@ -121,10 +121,16 @@ The following options are also available:
   Default: false
 * impact - analyze local changes to determine which hosts/roles to test.
   Default: false
-* ssh_cmd_gen_template - A variable to supply a custom ssh command
-  generator which will be invoked by TT to generate a vanilla command.
-  This can be expressed in a template format, with the arguments
-  supplied using `ssh_cmd_gen_args`
+* ssh_cmd_gen_template - Provide a command to run, whose stdout will be a
+  vanilla ssh command Taste Tester will invoke to access test nodes.
+  The command should be a template and will be passed the
+  following variables:
+  * `jumps` - any jumphost arguments supplied via -J option
+  * `host` - the host to SSH to
+  * `user` - the user to SSH as
+  For example:
+  `ssh_gen %{jumps} --user %{user} %{host}`
+  In addition, further arguments can be passed using `ssh_cmd_gen_args`
   Default: nil
 
 ## Plugin

--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ The following options are also available:
   * `user` - the user to SSH as
   For example:
   `ssh_gen %{jumps} --user %{user} %{host}`
-  In addition, further arguments can be passed using `ssh_cmd_gen_args`
   Default: nil
 
 ## Plugin

--- a/lib/taste_tester/commands.rb
+++ b/lib/taste_tester/commands.rb
@@ -109,6 +109,11 @@ module TasteTester
           tested_hosts << hostname
         rescue TasteTester::Exceptions::AlreadyTestingError => e
           logger.error("User #{e.username} is already testing on #{hostname}")
+        rescue StandardError => e
+          # Call error handling hook and re-raise
+          TasteTester::Hooks.post_error(TasteTester::Config.dryrun, e,
+                                        __method__, hostname)
+          raise
         end
       end
       unless TasteTester::Config.skip_post_test_hook ||
@@ -145,7 +150,14 @@ module TasteTester
       server = TasteTester::Server.new
       hosts.each do |hostname|
         host = TasteTester::Host.new(hostname, server)
-        host.untest
+        begin
+          host.untest
+        rescue StandardError => e
+          # Call error handling hook and re-raise
+          TasteTester::Hooks.post_error(TasteTester::Config.dryrun, e,
+                                        __method__, hostname)
+          raise
+        end
       end
     end
 
@@ -158,7 +170,14 @@ module TasteTester
       server = TasteTester::Server.new
       hosts.each do |hostname|
         host = TasteTester::Host.new(hostname, server)
-        host.runchef
+        begin
+          host.runchef
+        rescue StandardError => e
+          # Call error handling hook and re-raise
+          TasteTester::Hooks.post_error(TasteTester::Config.dryrun, e,
+                                        __method__, hostname)
+          raise
+        end
       end
     end
 
@@ -171,7 +190,14 @@ module TasteTester
       server = TasteTester::Server.new
       hosts.each do |hostname|
         host = TasteTester::Host.new(hostname, server)
-        host.keeptesting
+        begin
+          host.keeptesting
+        rescue StandardError => e
+          # Call error handling hook and re-raise
+          TasteTester::Hooks.post_error(TasteTester::Config.dryrun, e,
+                                        __method__, hostname)
+          raise
+        end
       end
     end
 

--- a/lib/taste_tester/config.rb
+++ b/lib/taste_tester/config.rb
@@ -54,7 +54,6 @@ module TasteTester
     ssh_command 'ssh'
     ssh_connect_timeout 5
     ssh_cmd_gen_template nil
-    ssh_cmd_gen_args {}
     use_ssl true
     chef_zero_logging true
     chef_config_path '/etc/chef'

--- a/lib/taste_tester/config.rb
+++ b/lib/taste_tester/config.rb
@@ -53,8 +53,8 @@ module TasteTester
     use_ssh_tunnels false
     ssh_command 'ssh'
     ssh_connect_timeout 5
-    ssh_cmd_template nil
-    ssh_gen_args {}
+    ssh_cmd_gen_template nil
+    ssh_cmd_gen_args {}
     use_ssl true
     chef_zero_logging true
     chef_config_path '/etc/chef'

--- a/lib/taste_tester/config.rb
+++ b/lib/taste_tester/config.rb
@@ -53,6 +53,8 @@ module TasteTester
     use_ssh_tunnels false
     ssh_command 'ssh'
     ssh_connect_timeout 5
+    ssh_cmd_template nil
+    ssh_gen_args {}
     use_ssl true
     chef_zero_logging true
     chef_config_path '/etc/chef'

--- a/lib/taste_tester/hooks.rb
+++ b/lib/taste_tester/hooks.rb
@@ -63,6 +63,11 @@ module TasteTester
     # If this method returns true, the default output will not be printed.
     def self.print_impact(_final_impact); end
 
+    # In the event of any failure, this hook will be called
+    # just before taste-tester throws an exception/exits
+    # Additional logging, output, or cleanup may be done here.
+    def self.post_error(_dryrun, _exception, _mode, _hostname); end
+
     def self.get(file)
       path = File.expand_path(file)
       logger.warn("Loading plugin at #{path}") unless TasteTester::Config.json

--- a/lib/taste_tester/ssh.rb
+++ b/lib/taste_tester/ssh.rb
@@ -28,6 +28,7 @@ module TasteTester
       @host = host
       @tunnel = tunnel
       @cmds = []
+      @ssh_gen_cmd = nil
     end
 
     def add(string)

--- a/lib/taste_tester/ssh.rb
+++ b/lib/taste_tester/ssh.rb
@@ -28,7 +28,7 @@ module TasteTester
       @host = host
       @tunnel = tunnel
       @cmds = []
-      @ssh_gen_cmd = nil
+      @ssh_generated_cmd = nil
     end
 
     def add(string)

--- a/lib/taste_tester/ssh_util.rb
+++ b/lib/taste_tester/ssh_util.rb
@@ -31,14 +31,13 @@ module TasteTester
         end
       end
 
-      def ssh_gen_cmd
+      def ssh_generated_cmd
         if TasteTester::Config.ssh_cmd_template
           # we store this generated command inside a class variable
           # so that we can directly refer to this while printing
           # logs and error messages
-          @ssh_gen_cmd =
-            Mixlib::ShellOut.new(ssh_cmd_generator).run_command.stdout.chomp
-          @ssh_gen_cmd
+          @ssh_generated_cmd ||=
+	            Mixlib::ShellOut.new(ssh_cmd_generator).run_command.stdout.chomp
         end
       end
 
@@ -50,7 +49,7 @@ module TasteTester
 
       def ssh_base_cmd
         if TasteTester::Config.ssh_cmd_template
-          ssh_gen_cmd
+          ssh_generated_cmd
         else
           ssh_vanilla_cmd
         end
@@ -62,7 +61,7 @@ module TasteTester
 
       def error!
         if TasteTester::Config.ssh_cmd_template
-          ssh_cmd = "#{@ssh_gen_cmd} -v"
+          ssh_cmd = "#{@ssh_generated_cmd} -v"
         else
           ssh_cmd = "#{ssh_base_cmd} -v #{ssh_target}"
         end

--- a/lib/taste_tester/ssh_util.rb
+++ b/lib/taste_tester/ssh_util.rb
@@ -27,7 +27,7 @@ module TasteTester
             :host => @host,
           }
           TasteTester::Config.ssh_cmd_gen_template %
-            base_gen_args.update(TasteTester::Config.ssh_cmd_gen_args)
+            base_gen_args
         end
       end
 
@@ -39,7 +39,7 @@ module TasteTester
           begin
             # run the generator command only if it's not run already
             if @ssh_generated_cmd.nil?
-              generator = Mixlib::ShellOut.new(ssh_cmd_generator)              
+              generator = Mixlib::ShellOut.new(ssh_cmd_generator)
               @ssh_generated_cmd = generator.run_command.stdout.chomp
               generator.error!
             end

--- a/lib/taste_tester/ssh_util.rb
+++ b/lib/taste_tester/ssh_util.rb
@@ -38,10 +38,10 @@ module TasteTester
           # logs and error messages
           begin
             # run the generator command only if it's not run already
-            if @ssh_generated_cmd.nil?
-              generator = Mixlib::ShellOut.new(ssh_cmd_generator)
-              @ssh_generated_cmd = generator.run_command.stdout.chomp
+            unless @ssh_generated_cmd
+              generator = Mixlib::ShellOut.new(ssh_cmd_generator).run_command
               generator.error!
+              @ssh_generated_cmd = generator.stdout.chomp
             end
             @ssh_generated_cmd
           rescue Mixlib::ShellOut::ShellCommandFailed => e

--- a/lib/taste_tester/ssh_util.rb
+++ b/lib/taste_tester/ssh_util.rb
@@ -37,9 +37,9 @@ module TasteTester
           # so that we can directly refer to this while printing
           # logs and error messages
           begin
-            generator = Mixlib::ShellOut.new(ssh_cmd_generator)
             # run the generator command only if it's not run already
             if @ssh_generated_cmd.nil?
+              generator = Mixlib::ShellOut.new(ssh_cmd_generator)              
               @ssh_generated_cmd = generator.run_command.stdout.chomp
               generator.error!
             end

--- a/lib/taste_tester/ssh_util.rb
+++ b/lib/taste_tester/ssh_util.rb
@@ -20,19 +20,19 @@ module TasteTester
       end
 
       def ssh_cmd_generator
-        if TasteTester::Config.ssh_cmd_template
+        if TasteTester::Config.ssh_cmd_gen_template
           base_gen_args = {
             :user => TasteTester::Config.user,
             :jumps => jumps,
             :host => @host,
           }
-          TasteTester::Config.ssh_cmd_template %
-            base_gen_args.update(TasteTester::Config.ssh_gen_args)
+          TasteTester::Config.ssh_cmd_gen_template %
+            base_gen_args.update(TasteTester::Config.ssh_cmd_gen_args)
         end
       end
 
       def ssh_generated_cmd
-        if TasteTester::Config.ssh_cmd_template
+        if TasteTester::Config.ssh_cmd_gen_template
           # we store this generated command inside a class variable
           # so that we can directly refer to this while printing
           # logs and error messages
@@ -62,7 +62,7 @@ module TasteTester
       end
 
       def ssh_base_cmd
-        if TasteTester::Config.ssh_cmd_template
+        if TasteTester::Config.ssh_cmd_gen_template
           ssh_generated_cmd
         else
           ssh_vanilla_cmd
@@ -79,7 +79,7 @@ module TasteTester
 
       ERRORMESSAGE
 
-        if TasteTester::Config.ssh_cmd_template
+        if TasteTester::Config.ssh_cmd_gen_template
           error += <<~ERRORMESSAGE
 
   The above command was generated, and it may be useful to run the generator directly instead:

--- a/lib/taste_tester/tunnel.rb
+++ b/lib/taste_tester/tunnel.rb
@@ -29,11 +29,14 @@ module TasteTester
 
     def initialize(host, server)
       @host = host
+      @port = TasteTester::Config.tunnel_port
       @server = server
+      @extra_options = '-o ServerAliveInterval=10 ' +
+        '-o ServerAliveCountMax=6 ' +
+        "-f -R #{@port}:localhost:#{@server.port} "
     end
 
     def run
-      @port = TasteTester::Config.tunnel_port
       logger.info("Setting up tunnel on port #{@port}")
       exec!(cmd, logger)
     rescue StandardError => e
@@ -54,9 +57,7 @@ module TasteTester
       # In most cases the first request from chef was "breaking" the tunnel,
       # in a way that port was still open, but subsequent requests were hanging.
       # This is reproducible and should be looked into.
-      cmd = "#{ssh_base_cmd} -o ServerAliveInterval=10 " +
-        "-o ServerAliveCountMax=6 -f -R #{@port}:localhost:#{@server.port} "
-      build_ssh_cmd(cmd, [cmds])
+      build_ssh_cmd(ssh_base_cmd, [cmds])
     end
 
     def self.kill(name)

--- a/spec/ssh_spec.rb
+++ b/spec/ssh_spec.rb
@@ -149,8 +149,8 @@ describe TasteTester::SSH do
       TasteTester::Config.user 'rossi'
       TasteTester::Config.ssh_cmd_template 'mock_generator_cmd ' +
         '%{arg1} %{arg2} %{jumps} %{host} --user %{user} --get-command'
-      ssh_gen_args_dict = { :arg1 => 'mock_arg1', :arg2 => 'mock_arg2' }
-      TasteTester::Config.ssh_gen_args ssh_gen_args_dict
+      ssh_gen_args_hash = { :arg1 => 'mock_arg1', :arg2 => 'mock_arg2' }
+      TasteTester::Config.ssh_gen_args ssh_gen_args_hash
       allow(mock_so).to receive(:run_command).and_return(mock_so)
       allow(mock_so).to receive(:error?).and_return(false)
       allow(mock_so).to receive(:stderr).and_return('')

--- a/spec/ssh_spec.rb
+++ b/spec/ssh_spec.rb
@@ -148,9 +148,7 @@ describe TasteTester::SSH do
       TasteTester::Config.jumps 'mock_jump_user@mock_jump_host'
       TasteTester::Config.user 'rossi'
       TasteTester::Config.ssh_cmd_gen_template 'mock_generator_cmd ' +
-        '%{arg1} %{arg2} %{jumps} %{host} --user %{user} --get-command'
-      ssh_cmd_gen_args_hash = { :arg1 => 'mock_arg1', :arg2 => 'mock_arg2' }
-      TasteTester::Config.ssh_cmd_gen_args ssh_cmd_gen_args_hash
+        'mock_arg1 mock_arg2 %{jumps} %{host} --user %{user} --get-command'
       allow(mock_so).to receive(:run_command).and_return(mock_so)
       allow(mock_so).to receive(:error?).and_return(false)
       allow(mock_so).to receive(:error!).and_return(mock_generated_cmd)

--- a/spec/ssh_spec.rb
+++ b/spec/ssh_spec.rb
@@ -1,0 +1,151 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+
+# Copyright 2020-present Facebook
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'logger'
+require 'base64'
+require 'between_meals/util'
+require_relative '../lib/taste_tester/logging'
+require_relative '../lib/taste_tester/exceptions'
+require_relative '../lib/taste_tester/ssh_util'
+require_relative '../lib/taste_tester/ssh'
+require_relative '../lib/taste_tester/config'
+
+describe TasteTester::SSH do
+  let(:logger) do
+    Logger.new('/dev/null')
+  end
+
+  let(:config_hash) do
+    TasteTester::Config.save(true)
+  end
+
+  let(:tt_ssh) do
+    TasteTester::SSH.new('mock_host')
+  end
+
+  before do
+    TasteTester::Config.restore(config_hash)
+  end
+  context 'test default config' do
+    it 'test ssh base command' do
+      expect(tt_ssh.ssh_base_cmd).to eq(
+        'ssh  ' +
+        '-T ' +
+        '-o BatchMode=yes ' +
+        '-o UserKnownHostsFile=/dev/null ' +
+        '-o StrictHostKeyChecking=no ' +
+        '-o ConnectTimeout=5',
+      )
+    end
+
+    it 'test ssh target' do
+      expect(tt_ssh.ssh_target).to eq(
+        'root@mock_host',
+      )
+    end
+
+    it 'test build ssh command' do
+      expect(tt_ssh.build_ssh_cmd('mock_ssh', ['cmd1', 'cmd2'])).to eq(
+        'mock_ssh root@mock_host ' +
+        "\"echo 'Y21kMSAmJiBjbWQy' | base64 --decode | bash -x\"",
+      )
+    end
+
+    it 'test ssh exception message' do
+      expect(
+        TasteTester::Logging.logger,
+      ).to receive(
+        :error,
+      ).with(
+        /ssh.*root@mock_host/,
+      )
+      expect { tt_ssh.error! }.to raise_error(
+        TasteTester::Exceptions::SshError,
+      )
+    end
+    after do
+      TasteTester::Config.restore(config_hash)
+    end
+  end
+
+  context 'test custom configs linux' do
+    before do
+      TasteTester::Config.ssh_connect_timeout 10
+      TasteTester::Config.jumps 'mock_jump_user@mock_jump_host'
+      TasteTester::Config.ssh_command 'mock_ssh_command'
+      TasteTester::Config.user 'rossi'
+    end
+
+    it 'test ssh base command' do
+      expect(tt_ssh.ssh_base_cmd).to eq(
+        'mock_ssh_command ' +
+        '-J mock_jump_user@mock_jump_host ' +
+        '-T ' +
+        '-o BatchMode=yes ' +
+        '-o UserKnownHostsFile=/dev/null ' +
+        '-o StrictHostKeyChecking=no ' +
+        '-o ConnectTimeout=10',
+      )
+    end
+
+    it 'test ssh target' do
+      expect(tt_ssh.ssh_target).to eq(
+        'rossi@mock_host',
+      )
+    end
+
+    it 'test build ssh command' do
+      expect(tt_ssh.build_ssh_cmd('mock_ssh', ['cmd1', 'cmd2'])).to eq(
+        'mock_ssh rossi@mock_host ' +
+        "\"echo 'Y21kMSAmJiBjbWQy' | base64 --decode | sudo bash -x\"",
+      )
+    end
+
+    it 'test ssh exception message' do
+      expect(
+        TasteTester::Logging.logger,
+      ).to receive(
+        :error,
+      ).with(
+        /mock_ssh_command.*mock_jump_user@mock_jump_host.*rossi@mock_host/,
+      )
+      expect { tt_ssh.error! }.to raise_error(
+        TasteTester::Exceptions::SshError,
+      )
+    end
+    after do
+      TasteTester::Config.restore(config_hash)
+    end
+  end
+
+  context 'test custom configs windows' do
+    before do
+      TasteTester::Config.user 'rossi'
+      TasteTester::Config.windows_target true
+    end
+    it 'test build ssh command' do
+      expect(tt_ssh.build_ssh_cmd('mock_ssh', ['cmd1', 'cmd2'])).to eq(
+        'mock_ssh rossi@mock_host ' +
+        "'[Text.Encoding]::Utf8.GetString([Convert]::" +
+        "FromBase64String('\"'Y21kMSA7IGNtZDI='))\"' " +
+        "| powershell.exe -c -; exit $LASTEXITCODE'",
+      )
+    end
+    after do
+      TasteTester::Config.restore(config_hash)
+    end
+  end
+end

--- a/spec/ssh_spec.rb
+++ b/spec/ssh_spec.rb
@@ -147,10 +147,10 @@ describe TasteTester::SSH do
       TasteTester::Config.ssh_connect_timeout 10
       TasteTester::Config.jumps 'mock_jump_user@mock_jump_host'
       TasteTester::Config.user 'rossi'
-      TasteTester::Config.ssh_cmd_template 'mock_generator_cmd ' +
+      TasteTester::Config.ssh_cmd_gen_template 'mock_generator_cmd ' +
         '%{arg1} %{arg2} %{jumps} %{host} --user %{user} --get-command'
-      ssh_gen_args_hash = { :arg1 => 'mock_arg1', :arg2 => 'mock_arg2' }
-      TasteTester::Config.ssh_gen_args ssh_gen_args_hash
+      ssh_cmd_gen_args_hash = { :arg1 => 'mock_arg1', :arg2 => 'mock_arg2' }
+      TasteTester::Config.ssh_cmd_gen_args ssh_cmd_gen_args_hash
       allow(mock_so).to receive(:run_command).and_return(mock_so)
       allow(mock_so).to receive(:error?).and_return(false)
       allow(mock_so).to receive(:error!).and_return(mock_generated_cmd)

--- a/spec/tunnel_spec.rb
+++ b/spec/tunnel_spec.rb
@@ -29,6 +29,14 @@ describe TasteTester::Tunnel do
     Logger.new('/dev/null')
   end
 
+  let(:config_hash) do
+    TasteTester::Config.save(true)
+  end
+
+  before do
+    TasteTester::Config.restore(config_hash)
+  end
+
   before do
     allow_any_instance_of(
       TasteTester::Server,
@@ -62,6 +70,9 @@ describe TasteTester::Tunnel do
         '| base64 --decode | bash -x',
       )
     end
+    after do
+      TasteTester::Config.restore(config_hash)
+    end
   end
 
   context 'test custom configs linux' do
@@ -91,10 +102,17 @@ describe TasteTester::Tunnel do
         '| base64 --decode | sudo bash -x',
       )
     end
+    after do
+      TasteTester::Config.restore(config_hash)
+    end
   end
 
   context 'test custom configs windows' do
     before do
+      TasteTester::Config.ssh_connect_timeout 10
+      TasteTester::Config.jumps 'mock_jump_user@mock_jump_host'
+      TasteTester::Config.ssh_command 'mock_ssh_command'
+      TasteTester::Config.user 'rossi'
       TasteTester::Config.windows_target true
     end
     it 'test build tunnel command' do
@@ -115,6 +133,9 @@ describe TasteTester::Tunnel do
       expect(tt_tunnel.cmd).to include(
         'powershell.exe -c -; exit $LASTEXITCODE',
       )
+    end
+    after do
+      TasteTester::Config.restore(config_hash)
     end
   end
 end

--- a/spec/tunnel_spec.rb
+++ b/spec/tunnel_spec.rb
@@ -1,0 +1,120 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+
+# Copyright 2020-present Facebook
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'logger'
+require 'base64'
+require 'between_meals/util'
+require_relative '../lib/taste_tester/logging'
+require_relative '../lib/taste_tester/exceptions'
+require_relative '../lib/taste_tester/ssh_util'
+require_relative '../lib/taste_tester/tunnel'
+require_relative '../lib/taste_tester/config'
+require_relative '../lib/taste_tester/server'
+
+describe TasteTester::Tunnel do
+  let(:logger) do
+    Logger.new('/dev/null')
+  end
+
+  before do
+    allow_any_instance_of(
+      TasteTester::Server,
+    ).to receive(:port).and_return(1234)
+  end
+
+  let(:mock_server) do
+    TasteTester::Server.new
+  end
+
+  let(:tt_tunnel) do
+    TasteTester::Tunnel.new('mock_host', mock_server)
+  end
+
+  context 'test base configs' do
+    it 'test build tunnel command' do
+      expect(tt_tunnel.cmd).to include(
+        'ssh  ' +
+        '-T ' +
+        '-o BatchMode=yes ' +
+        '-o UserKnownHostsFile=/dev/null ' +
+        '-o StrictHostKeyChecking=no ' +
+        '-o ConnectTimeout=5 ' +
+        '-o ServerAliveInterval=10 ' +
+        '-o ServerAliveCountMax=6 ' +
+        '-f ' +
+        '-R :localhost:1234  ' +
+        'root@mock_host',
+      )
+      expect(tt_tunnel.cmd).to include(
+        '| base64 --decode | bash -x',
+      )
+    end
+  end
+
+  context 'test custom configs linux' do
+    before do
+      TasteTester::Config.ssh_connect_timeout 10
+      TasteTester::Config.jumps 'mock_jump_user@mock_jump_host'
+      TasteTester::Config.ssh_command 'mock_ssh_command'
+      TasteTester::Config.user 'rossi'
+    end
+
+    it 'test build tunnel command' do
+      expect(tt_tunnel.cmd).to include(
+        'mock_ssh_command ' +
+        '-J mock_jump_user@mock_jump_host ' +
+        '-T ' +
+        '-o BatchMode=yes ' +
+        '-o UserKnownHostsFile=/dev/null ' +
+        '-o StrictHostKeyChecking=no ' +
+        '-o ConnectTimeout=10 ' +
+        '-o ServerAliveInterval=10 ' +
+        '-o ServerAliveCountMax=6 ' +
+        '-f ' +
+        '-R :localhost:1234  ' +
+        'rossi@mock_host',
+      )
+      expect(tt_tunnel.cmd).to include(
+        '| base64 --decode | sudo bash -x',
+      )
+    end
+  end
+
+  context 'test custom configs windows' do
+    before do
+      TasteTester::Config.windows_target true
+    end
+    it 'test build tunnel command' do
+      expect(tt_tunnel.cmd).to include(
+        'mock_ssh_command ' +
+        '-J mock_jump_user@mock_jump_host ' +
+        '-T ' +
+        '-o BatchMode=yes ' +
+        '-o UserKnownHostsFile=/dev/null ' +
+        '-o StrictHostKeyChecking=no ' +
+        '-o ConnectTimeout=10 ' +
+        '-o ServerAliveInterval=10 ' +
+        '-o ServerAliveCountMax=6 ' +
+        '-f ' +
+        '-R :localhost:1234  ' +
+        'rossi@mock_host',
+      )
+      expect(tt_tunnel.cmd).to include(
+        'powershell.exe -c -; exit $LASTEXITCODE',
+      )
+    end
+  end
+end

--- a/spec/tunnel_spec.rb
+++ b/spec/tunnel_spec.rb
@@ -63,7 +63,7 @@ describe TasteTester::Tunnel do
         '-o ServerAliveInterval=10 ' +
         '-o ServerAliveCountMax=6 ' +
         '-f ' +
-        '-R :localhost:1234  ' +
+        '-R 4001:localhost:1234 ' +
         'root@mock_host',
       )
       expect(tt_tunnel.cmd).to include(
@@ -95,7 +95,7 @@ describe TasteTester::Tunnel do
         '-o ServerAliveInterval=10 ' +
         '-o ServerAliveCountMax=6 ' +
         '-f ' +
-        '-R :localhost:1234  ' +
+        '-R 4001:localhost:1234 ' +
         'rossi@mock_host',
       )
       expect(tt_tunnel.cmd).to include(
@@ -127,7 +127,7 @@ describe TasteTester::Tunnel do
         '-o ServerAliveInterval=10 ' +
         '-o ServerAliveCountMax=6 ' +
         '-f ' +
-        '-R :localhost:1234  ' +
+        '-R 4001:localhost:1234 ' +
         'rossi@mock_host',
       )
       expect(tt_tunnel.cmd).to include(


### PR DESCRIPTION
Tested with and without `ssh_command_generator` in the config

* Without
```
The host might be broken or your SSH access is not working properly
Try doing

    TERM=screen.xterm-256color SSH_AUTH_SOCK=/tmp/cloud-ssh-nish-agent /bin/ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 22  -T -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ConnectTimeout=60 -v centos@<redacted_host>

to see if ssh connection is good.

If ssh works, add '-v' key to taste-tester to see the list of commands it's
trying to execute, and try to run them manually on destination host
```

* With
```
The host might be broken or your SSH access is not working properly
Try doing

    TERM=screen.xterm-256color SSH_AUTH_SOCK=/tmp/cloud-ssh-nish-agent /bin/ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 22  -T -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ConnectTimeout=60 -v centos@<redacted_host>

to see if ssh connection is good.

The above command was generated, and it may be useful to run the generator directly instead:

    <redacted generator command>

If ssh works, add '-v' key to taste-tester to see the list of commands it's
trying to execute, and try to run them manually on destination host
```